### PR TITLE
Encode email address when signing up and verifying

### DIFF
--- a/src/components/Signup/Signup.tsx
+++ b/src/components/Signup/Signup.tsx
@@ -14,7 +14,7 @@ export default function Signup() {
     setPending(true);
 
     try {
-      const path = `https://dotcom.val.run/signup?email=${email}`;
+      const path = `https://dotcom.val.run/signup?email=${encodeURIComponent(email)}`;
       const body = new FormData();
       body.append("email", email);
 

--- a/src/components/Verify/Verify.tsx
+++ b/src/components/Verify/Verify.tsx
@@ -1,5 +1,5 @@
-import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import Header from "@/components/Header";
 import styles from "./Verify.module.css";
 
 interface VerifyProps {
@@ -79,8 +79,8 @@ const Invalid = ({ reason }: { reason: string }) => {
 
 async function verify(email: string, token: string) {
   const response = await fetch(
-    `https://dotcom.val.run/verify?email=${email}&token=${token}`,
-    { method: "POST" }
+    `https://dotcom.val.run/verify?email=${encodeURIComponent(email)}&token=${encodeURIComponent(token)}`,
+    { method: "POST" },
   );
   const data = await response.json();
 


### PR DESCRIPTION
Handles email addresses with `+`, which weren't properly encoded before